### PR TITLE
Fix command for finding and deleting old backups

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -180,7 +180,7 @@ if [ $BACKUP_SUCCESS =  0 ];
 then
       echo -e "${green}${bold}RaspberryPI backup process completed! FILE: $OFILE${NC}${normal}" | tee -a $DIR/backup.log
       echo -e "${yellow}Removing backups older than $RETENTIONPERIOD days${NC}" | tee -a $DIR/backup.log
-      sudo find $DIR -maxdepth 1 -name "*.img" -o -name "*.gz" -mtime +$RETENTIONPERIOD -exec rm {} \;
+      sudo find $DIR -maxdepth 1 -mtime +$RETENTIONPERIOD \( -name "*.img" -o -name "*.gz" \) -exec rm {} \;
       echo -e "${cyan}If any backups older than $RETENTIONPERIOD days were found, they were deleted${NC}" | tee -a $DIR/backup.log
 
  


### PR DESCRIPTION
Previously, the `find` command would list all the `*.img` files because order of the operators were not correct. What the command translated to is:

> Find all the files with the name `*.img`. If nothing was found, then find all the files with the name `*.gz` that have been modified over `RETENTIONPERIOD` hours.

For me, this listed all my `.img` files and was deleting all them of them. I was wondering why the script never created any backups...they were being deleted right away.

What we want is:

> Find all the files modified over `RETENTIONPERIOD` hours, with the name `*.img` OR `*.gz`.

This fixed the problem for me.